### PR TITLE
fix: 修改toast底部显示位置

### DIFF
--- a/harmony/rn_toast/src/main/ets/ToastModule.ts
+++ b/harmony/rn_toast/src/main/ets/ToastModule.ts
@@ -63,7 +63,7 @@ export class ToastModule extends TurboModule {
         addPixelsY = options['addPixelsY'];
       }
     }
-    let alignPost = Alignment.BottomEnd;
+    let alignPost = Alignment.Bottom;
     if (position === "top") {
       alignPost = Alignment.Top;
       addPixelsY += 20;


### PR DESCRIPTION
# Summary

fix: 修改toast底部显示位置 (#12)

## TestPlan

点击界面bottom底部弹框显示位置

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例
- [ ] 已经更新了文档
- [X] 更新了 JS/TS 代码
